### PR TITLE
correcting typo in the command

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -11,7 +11,7 @@ source venv/bin/activate
 
 Install all requirements
 ```
-pip install -r requirement.txt
+pip install -r requirements.txt
 ```
 
 Train word2vec and generate files *sampleVectors.json* and *word_vectors.png*


### PR DESCRIPTION
Should be `pip install -r requirements.txt` rather than `pip install -r requirement.txt`